### PR TITLE
add openssh-client to Dockerfile

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN install_packages \
   gosu \
   libaio1 \
   locales \
+  openssh-client \
   pkg-config \
   procps \
   python3 \


### PR DESCRIPTION
If you are using ssh to authenticate with git repositories, you need this.